### PR TITLE
Clock

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<title>Momentum-Clone-App</title>
 		<meta name="viewport" content="width=device-width">
-		
+
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css">
 
 		<link rel="stylesheet" href="main.css">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <html>
 	<head>
 		<title>Momentum-Clone-App</title>
+		<meta name="viewport" content="width=device-width">
+		
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css">
 
 		<link rel="stylesheet" href="main.css">

--- a/main.css
+++ b/main.css
@@ -246,6 +246,12 @@ CLOCK/GREETING
   }
 }
 
+@media screen and (max-height:600px) {  
+  #clock {
+    display: none;
+  }
+}
+
 @media screen and (min-width: 600px){
   #clock  {
     font-size: 100px;
@@ -268,6 +274,18 @@ CLOCK/GREETING
 #greeting {
 	white-space: nowrap;
 	font-weight: 700;
+}
+
+@media screen and (max-width:599px) {  
+  #greeting {
+    display: none;
+  }
+}
+
+@media screen and (max-height:600px) {  
+  #greeting {
+    display: none;
+  }
 }
 
 @media screen and (min-width: 200px){
@@ -324,12 +342,12 @@ TO DO LIST & FOCUS
 }
 
 #focusContainer {
-	position: fixed;
-	bottom: 75px;
+
 	font-size: 40px;
 	font-weight: 600;
 	width: 800px;
 }
+
 
 @media screen and (max-width: 600px){
   #focusContainer {
@@ -342,6 +360,13 @@ TO DO LIST & FOCUS
     font-size: 40px;
   }
 }
+
+@media screen and (max-height: 600px){
+  #focusContainer {
+    font-size: 20px;
+  }
+}
+
 
 #focusContainer label {
 	font-weight: 200;

--- a/main.css
+++ b/main.css
@@ -214,18 +214,78 @@ CLOCK/GREETING
 +++++ */
 
 #date {
-	font-size: 45px;
 	font-weight: 400;
+	white-space: nowrap;
+}
+
+@media screen and (min-width: 200px){
+  #date  {
+    font-size: 30px;
+  }
+}
+
+@media screen and (min-width: 724px){
+  #date  {
+    font-size: 40px;
+  }
+}
+
+@media screen and (min-width: 1240px){
+  #date  {
+    font-size: 45px;
+  }
 }
 
 #clock {
-	font-size: 150px;
 	font-weight: 700;
 }
 
+@media screen and (max-width:599px) {  
+  #clock {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 600px){
+  #clock  {
+    font-size: 100px;
+  }
+}
+
+@media screen and (min-width: 724px){
+  #clock  {
+    font-size: 130px;
+  }
+}
+
+@media screen and (min-width: 1240px){
+  #clock  {
+    font-size: 160px;
+  }
+}
+
+
 #greeting {
-	font-size: 60px;
+	white-space: nowrap;
 	font-weight: 700;
+}
+
+@media screen and (min-width: 200px){
+  #greeting  {
+    font-size: 40px;
+  }
+}
+
+@media screen and (min-width: 724px){
+  #greeting  {
+    font-size: 50px;
+  }
+}
+
+@media screen and (min-width: 1240px){
+  #greeting  {
+    font-size: 60px;
+  }
 }
 
 /* +++++
@@ -264,9 +324,23 @@ TO DO LIST & FOCUS
 }
 
 #focusContainer {
+	position: fixed;
+	bottom: 75px;
 	font-size: 40px;
 	font-weight: 600;
 	width: 800px;
+}
+
+@media screen and (max-width: 600px){
+  #focusContainer {
+    font-size: 30px;
+  }
+}
+
+@media screen and (min-width: 1240px){
+  #focusContainer {
+    font-size: 40px;
+  }
 }
 
 #focusContainer label {

--- a/main.css
+++ b/main.css
@@ -66,10 +66,6 @@ html {
  /* background-image: url("https://source.unsplash.com/category/nature/1920x1080/daily");*/
 }
 
-div {
-	outline: 1px solid yellow;
-}
-
 /*
 ==========
 PAGE STRUCTURE

--- a/main.css
+++ b/main.css
@@ -66,6 +66,10 @@ html {
  /* background-image: url("https://source.unsplash.com/category/nature/1920x1080/daily");*/
 }
 
+div {
+	outline: 1px solid yellow;
+}
+
 /*
 ==========
 PAGE STRUCTURE
@@ -83,7 +87,6 @@ PAGE STRUCTURE
 
 .bottom {
   bottom: 0;
-	max-height: 100px;
 }
 
 .left {
@@ -240,13 +243,13 @@ CLOCK/GREETING
 	font-weight: 700;
 }
 
-@media screen and (max-width:599px) {  
+@media screen and (max-width:599px) {
   #clock {
     display: none;
   }
 }
 
-@media screen and (max-height:600px) {  
+@media screen and (max-height:600px) {
   #clock {
     display: none;
   }
@@ -276,13 +279,13 @@ CLOCK/GREETING
 	font-weight: 700;
 }
 
-@media screen and (max-width:599px) {  
+@media screen and (max-width:599px) {
   #greeting {
     display: none;
   }
 }
 
-@media screen and (max-height:600px) {  
+@media screen and (max-height:600px) {
   #greeting {
     display: none;
   }
@@ -342,7 +345,6 @@ TO DO LIST & FOCUS
 }
 
 #focusContainer {
-
 	font-size: 40px;
 	font-weight: 600;
 	width: 800px;
@@ -450,6 +452,10 @@ QUOTES
 
 #quote-citation {
 	font-size: 0.85em;
-	margin-top: 15px;
+	margin-top: 10px;
 	display: none;
+}
+
+.onhover {
+	padding-bottom: 5px;
 }

--- a/quote.js
+++ b/quote.js
@@ -1,13 +1,13 @@
 $(document).ready(function() {
   var qod = $.getJSON("http://quotes.rest/qod.json?category=inspire", function(data) {
     console.log(data);
-    $("#quotes").html(data.contents.quotes[0].quote);
+    $("#quotes").html(/*data.contents.quotes[0].quote*/ "That's my last duchess painted on the wall / looking as if she were alive. I call / that piece a wonder now. Fra Pandolf's hand / worked busily a day and there she stands. Will it please you sit and look at her? I said...");
     $("#quote-author").html(data.contents.quotes[0].author);
   });
 
 $("#quote-container").hover(function() {
 	$("#quote-citation").toggle();
-  $("#quote-container").css("max-height", "92px");
+  $("#quote-container").toggleClass("onhover");
 });
 
 });

--- a/quote.js
+++ b/quote.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
   var qod = $.getJSON("http://quotes.rest/qod.json?category=inspire", function(data) {
     console.log(data);
-    $("#quotes").html(/*data.contents.quotes[0].quote*/ "That's my last duchess painted on the wall / looking as if she were alive. I call / that piece a wonder now. Fra Pandolf's hand / worked busily a day and there she stands. Will it please you sit and look at her? I said...");
+    $("#quotes").html(data.contents.quotes[0].quote);
     $("#quote-author").html(data.contents.quotes[0].author);
   });
 

--- a/quote.js
+++ b/quote.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
 
 $("#quote-container").hover(function() {
 	$("#quote-citation").toggle();
-  $("#quote-container").css("max-height", "150px");
+  $("#quote-container").css("max-height", "92px");
 });
 
 });


### PR DESCRIPTION
Update from the last pull request.

1. #focusContainer had a the class of container which was already fixed but there were still issues with overlapping. The workaround for that has been removing both the clock and greeting when min height and width is under 600px.

2. Added fix on the quote overlapping issue. 